### PR TITLE
修复在Safari下二级导航异常偏移的问题

### DIFF
--- a/source/css/_layout/head.styl
+++ b/source/css/_layout/head.styl
@@ -309,7 +309,7 @@
         display: none
         margin-top: 8px
         width: max-content
-        animation: sub_menus .3s .1s ease both
+        animation: 0.3s ease 0.1s 1 normal both sub_menu
 
         &:before
           position: absolute


### PR DESCRIPTION
二级导航栏适配Safari