### PR TITLE
feat: support action publish npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: npm publish
+
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
嗨，下午好。

首先 🙏 感谢 hexo-theme-Acrylic 的付出和贡献，这个PR做了一些简单的工作。

这个更改用于支持发布版本时自动更新 npm 包。

但是还额外需要您（仓库的管理者）进行一些配置，下面是一个大概的步骤：

1. 登陆到 npm，创建一个新的用于 CI/CD 的token令牌。

这是一个快捷链接：https://www.npmjs.com/settings/您的用户名称/tokens

2. 在仓库的设置页面，**Settings - Security - Secrets and variables - Actions**
    新增并配置上面新创建的令牌内容。
    
    
<img width="1245" alt="image" src="https://user-images.githubusercontent.com/18086072/233832396-23f7100a-9512-4409-9d2c-302017679366.png">

    
    
3. 在仓库发布新的版本，您可以看到 Actions  会运行 npm publish 的任务。


当然，您也有其他的选择：

例如：
1. 直接点击 Actions 面板
2. 点击新增工作流
3. 然后选择  Publish Node.js Package 进行修改
4. 重复上述的令牌创建和设置工作

当发布完成，您即可在 README.md 中新增 ``` npm i hexo-theme-acrylic ``` 相关描述。

